### PR TITLE
liveleak: change regex to match changed html from liveleak

### DIFF
--- a/source/video.brs
+++ b/source/video.brs
@@ -1933,8 +1933,8 @@ Function getLiveleakMP4Url(video as Object, timeout = 0 as Integer, loginCookie 
     video["Streams"].Clear()
 
     if ( video["URL"] <> invalid ) then
-        liveleakMP4UrlRegex = CreateObject( "roRegex", "source\s+src=\" + Quote() + "(.*)\" + Quote() + "[^>]*res=\" + Quote() + "SD\" + Quote() , "ig" )
-        liveleakMP4HDUrlRegex = CreateObject( "roRegex", "source\s+src=\" + Quote() + "(.*)\" + Quote() + "[^>]*res=\" + Quote() + "HD\" + Quote(), "ig" )
+        liveleakMP4UrlRegex = CreateObject( "roRegex", "source\s+src=\" + Quote() + "(.*)\" + Quote() + "[^>]*label=\" + Quote() + "(SD|360p)\" + Quote() , "ig" )
+        liveleakMP4HDUrlRegex = CreateObject( "roRegex", "source\s+src=\" + Quote() + "(.*)\" + Quote() + "[^>]*label=\" + Quote() + "HD\" + Quote(), "ig" )
         
         url = video["URL"]
         port = CreateObject( "roMessagePort" )


### PR DESCRIPTION
1. Match string changed from res= to label=

2. I noticed one video with a label="360p". Existing code is matching only label="SD" and label="HD".  I changed the SD regex to match either SD or 360p. I'd imagine it may be possible for videos to have both SD and 360p versions listed, and this may match the lesser quality one, but I'd think it'd be rare. (I didn't see any examples of that in a few hundred videos.)  Doesn't seem worth the effort of coding another tier. You don't want to see the example video, trust me on this one. 

3. I noticed that it's possible for the video on a liveleak page to be an embedded youtube video. INCEPTION. I'm leaving that one alone. Here is an example, for the record: https://www.liveleak.com/view?i=196_1519606734&ajax=1

