### PR TITLE
add domain support to reddit module

### DIFF
--- a/source/reddit.brs
+++ b/source/reddit.brs
@@ -162,9 +162,13 @@ Function QueryReddit(multireddits = "videos" as String) As Object
     if (Instr(0, multireddits, "http://")) then
         http = NewHttp( multireddits )
     else
+        stub = "r"
+        if (Instr(0, multireddits, ".")) then
+            stub = "domain"
+        end if
         redditQueryType = LCase( firstValid( getEnumValueForType( getConstants().eREDDIT_QUERIES, prefs.getPrefValue( prefs.RedditFeed.key ) ), "Hot" ) )
         redditFilterType = LCase( firstValid( getEnumValueForType( getConstants().eREDDIT_FILTERS, prefs.getPrefValue( prefs.RedditFilter.key ) ), "All" ) )
-        http = NewHttp("http://www.reddit.com/r/" + multireddits + "/" + redditQueryType + ".json?t=" + redditFilterType)
+        http = NewHttp("http://www.reddit.com/" + stub + "/" + multireddits + "/" + redditQueryType + ".json?t=" + redditFilterType)
     end if
     headers = {}
 


### PR DESCRIPTION
The reddit site-wide by-domain view:
`https://www.reddit.com/domain/youtube.com/`

Is the same structure, uses the same feeds, and accepts the same filters as the by-subreddit view:
`https://www.reddit.com/r/VideoBuzz`

Subreddits cannot contain a period (.). Domains all contain a period.

VB's existing by-subreddit functionality can be made to handle domains by 1) checking the entry for a period. 2) If it contains a period, use the /domain/ URL instead of the /r/ URL.

Domains VB will support: youtu.be. youtube.com, m.youtube.com gfycat.com, streamable.com, liveleak.com vine.co 

(Included for completeness.) Some domains that VB once supported no longer work with VB. This may be temporarily broken, or permanently broken, I don't know. I checked these & determined they do not currently work with VB: drive.google.com docs.google.com vidzi.tv  